### PR TITLE
fix(nextjs/checkout): use NextResponse.redirect(url) instead of redirect

### DIFF
--- a/packages/nextjs/src/checkout/checkout.ts
+++ b/packages/nextjs/src/checkout/checkout.ts
@@ -1,5 +1,4 @@
 import { NextRequest, NextResponse } from "next/server";
-import { redirect } from "next/navigation";
 import {
   buildCheckoutUrl,
   CheckoutHandlerConfig,
@@ -39,7 +38,7 @@ export const Checkout = (config: CheckoutHandlerConfig) => {
       return new NextResponse(error.message, { status: 400 });
     }
 
-    redirect(url);
+    return NextResponse.redirect(url);
   };
 
   const postHandler = async (req: NextRequest) => {
@@ -64,7 +63,7 @@ export const Checkout = (config: CheckoutHandlerConfig) => {
     } catch (error: any) {
       return new NextResponse(error.message, { status: 400 });
     }
-    redirect(url);
+    return NextResponse.redirect(url);
   };
 
   return (req: NextRequest) => {


### PR DESCRIPTION
The redirect function was causing some obsure error related to mutated cookies when running in an example nextjs app. This fixes that