### PR TITLE
betterauth: add Checkout Sessions endpoint and docs; revert example t…

### DIFF
--- a/packages/betterauth/README.md
+++ b/packages/betterauth/README.md
@@ -6,6 +6,7 @@ A Better Auth plugin for integrating Dodo Payments into your authentication flow
 
 - **Automatic Customer Management** - Creates Dodo Payments customers when users sign up
 - **Secure Checkout Integration** - Type-safe checkout flows with product slug mapping
+- **Modern Checkout Sessions** - Enhanced checkout experience with the latest Dodo Payments API
 - **Customer Portal Access** - Self-service portal for subscription and payment management
 - **Webhook Event Handling** - Real-time payment event processing with signature verification
 - **TypeScript Support** - Full type safety with TypeScript definitions
@@ -67,6 +68,7 @@ export const { auth, endpoints, client } = BetterAuth({
           ],
           successUrl: "/dashboard/success",
           authenticatedUsersOnly: true, // Require login for checkout
+          enableCheckoutSessions: true, // Enable modern checkout sessions
         }),
         portal(),
         webhooks({
@@ -100,7 +102,7 @@ export const authClient = createAuthClient({
 
 ## Usage
 
-### Creating a Checkout Session
+### Creating a Checkout Session (Dynamic Checkout)
 
 ```typescript
 // Create checkout with customer details
@@ -123,6 +125,63 @@ const { data: checkout, error } = await authClient.dodopayments.checkout({
 
 // Redirect to checkout URL
 window.location.href = checkout.url;
+```
+
+### Creating a Modern Checkout Session
+
+When `enableCheckoutSessions: true` is set in the checkout configuration, you can use the modern checkout sessions API:
+
+```typescript
+// Create modern checkout session with enhanced features
+const { data: checkoutSession, error } = await authClient.dodopayments.checkoutSession({
+  slug: "premium-plan", // The slug you provided in the checkout configuration
+  product_cart: [
+    {
+      product_id: "pdt_xxxxxxxxxxxxxxxxxxxxx", // Your product ID
+      quantity: 1,
+    },
+  ],
+  customer: {
+    email: "customer@example.com",
+    name: "John Doe",
+    phone_number: "+1234567890", // Optional
+  },
+  billing_address: {
+    street: "123 Market St",
+    city: "San Francisco",
+    state: "CA",
+    country: "US",
+    zipcode: "94103",
+  },
+  return_url: "https://yoursite.com/success",
+  allowed_payment_method_types: ["credit", "debit", "apple_pay", "google_pay"],
+  billing_currency: "USD",
+  show_saved_payment_methods: true,
+  discount_code: "SAVE10", // Optional
+  metadata: {
+    order_id: "order_123",
+    campaign: "summer_sale",
+  },
+  customization: {
+    theme: "light", // "light", "dark", or "system"
+    show_order_details: true,
+    show_on_demand_tag: false,
+  },
+  feature_flags: {
+    allow_currency_selection: true,
+    allow_discount_code: true,
+    allow_phone_number_collection: true,
+    allow_tax_id: false,
+    always_create_new_customer: false,
+  },
+  subscription_data: {
+    trial_period_days: 7, // Optional trial period
+  },
+  referenceId: "order_123", // Optional reference for your records
+});
+
+// Redirect to checkout URL
+window.location.href = checkoutSession.url;
 ```
 
 ### Accessing Customer Portal
@@ -194,6 +253,7 @@ webhooks({
 - **`products`** - Array of products or async function returning products
 - **`successUrl`** - URL to redirect after successful payment
 - **`authenticatedUsersOnly`** - Require user authentication (default: false)
+- **`enableCheckoutSessions`** - Enable modern checkout sessions API (default: false)
 
 ## Prompt for LLMs
 

--- a/packages/betterauth/src/index.ts
+++ b/packages/betterauth/src/index.ts
@@ -13,6 +13,7 @@ export type {
   SubscriptionItems,
   CustomerPortalResponse,
   CreateCheckoutResponse,
+  CreateCheckoutSessionResponse,
   WebhookResponse,
 } from "./types";
 

--- a/packages/betterauth/src/types.ts
+++ b/packages/betterauth/src/types.ts
@@ -50,4 +50,5 @@ export type PaymentItems = { items: PaymentsList["items"] };
 export type SubscriptionItems = { items: SubscriptionsList["items"] };
 export type CustomerPortalResponse = { url: string; redirect: boolean };
 export type CreateCheckoutResponse = { url: string; redirect: boolean };
+export type CreateCheckoutSessionResponse = { url: string; redirect: boolean };
 export type WebhookResponse = { received: boolean };


### PR DESCRIPTION
### 📝 Description
Adds Checkout Sessions support to the Better-Auth adapter by introducing an optional endpoint `/dodopayments/checkout/session` gated by `enableCheckoutSessions`. Updates types and README with usage and configuration. Reverts example app to original state (no test scaffolding).  
Closes #48 .

### 🔄 Type of Change
- [x] ✨ New feature
- [x] 📚 Documentation

### 🎯 Affected Packages
- [x] `@dodopayments/betterauth`
- [x] Documentation

### 📚 Documentation
- [x] Updated `packages/betterauth/README.md` with:
  - Feature overview
  - Config (`enableCheckoutSessions`)
  - Client usage patterns

### 🔍 Code Quality
- [x] Follows project style guidelines
- [x] Self-reviewed
- [x] No new warnings
- [x] Basic input validation via Zod, consistent error handling

### 🔐 Security Considerations
- [x] No secrets exposed
- [x] No new vulnerabilities introduced
- [x] Proper input validation (Zod)
- [x] Safe error messages

### 📖 Additional Context
- Endpoint name: `checkoutSession` (client method available as `authClient.dodopayments.checkout.session` due to Better-Auth client generation rules).
- Example app reverted to original (no test pages/links).

### Reviewer Notes
- [x] API Design: Endpoint gated via `enableCheckoutSessions`, consistent with plugin pattern.
- [x] Error Handling: Uses `APIError` with appropriate status codes.
- [x] Type Safety: Zod schemas and exported TS types added.
- [x] Documentation: Usage and configuration covered.
- [x] Security: No sensitive data exposure.

### 📋 Pre-merge Checklist
- [ ] All CI checks passing
- [x] Code reviewed
- [x] Documentation updated
- [ ] CHANGELOG updated (if required by release process)