### PR TITLE
fix(release): add repository field to all published packages

### DIFF
--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -49,5 +49,9 @@
   "files": [
     "dist",
     "llm-prompt.txt"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dodopayments/dodo-adapters.git"
+  }
 }

--- a/packages/betterauth/package.json
+++ b/packages/betterauth/package.json
@@ -48,5 +48,9 @@
   "files": [
     "dist",
     "llm-prompt.txt"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dodopayments/dodo-adapters.git"
+  }
 }

--- a/packages/convex/package.json
+++ b/packages/convex/package.json
@@ -56,5 +56,9 @@
   "type": "module",
   "files": [
     "dist"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dodopayments/dodo-adapters.git"
+  }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -61,5 +61,9 @@
     "email": "support@dodopayments.com",
     "url": "https://dodopayments.com"
   },
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dodopayments/dodo-adapters.git"
+  }
 }

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -46,5 +46,9 @@
   "type": "module",
   "files": [
     "dist"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dodopayments/dodo-adapters.git"
+  }
 }

--- a/packages/fastify/package.json
+++ b/packages/fastify/package.json
@@ -50,5 +50,9 @@
   "files": [
     "dist",
     "llm-prompt.txt"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dodopayments/dodo-adapters.git"
+  }
 }

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -49,5 +49,9 @@
   "files": [
     "dist",
     "llm-prompt.txt"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dodopayments/dodo-adapters.git"
+  }
 }

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -49,5 +49,9 @@
   "files": [
     "dist",
     "llm-prompt.txt"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dodopayments/dodo-adapters.git"
+  }
 }

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -50,5 +50,9 @@
     "email": "support@dodopayments.com",
     "url": "https://dodopayments.com"
   },
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dodopayments/dodo-adapters.git"
+  }
 }

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -49,5 +49,9 @@
   "files": [
     "dist",
     "llm-prompt.txt"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dodopayments/dodo-adapters.git"
+  }
 }

--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -49,5 +49,9 @@
   "files": [
     "dist",
     "llm-prompt.txt"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dodopayments/dodo-adapters.git"
+  }
 }

--- a/packages/tanstack/package.json
+++ b/packages/tanstack/package.json
@@ -49,5 +49,9 @@
   "files": [
     "dist",
     "llm-prompt.txt"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dodopayments/dodo-adapters.git"
+  }
 }


### PR DESCRIPTION
## Summary
- Adds `repository` field with type and URL to all 12 published packages
- Required for npm trusted publishing (provenance) to work correctly

## Packages updated
- `@dodopayments/core`
- `@dodopayments/nextjs`
- `@dodopayments/better-auth`
- `@dodopayments/nuxt`
- `@dodopayments/express`
- `@dodopayments/astro`
- `@dodopayments/remix`
- `@dodopayments/sveltekit`
- `@dodopayments/tanstack`
- `@dodopayments/fastify`
- `@dodopayments/hono`
- `@dodopayments/convex`


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added repository information to package metadata across all modules.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->