### PR TITLE
ci(sonarqube): run the scan on in-cluster arc-shared runners

### DIFF
--- a/.github/workflows/sonarqube.yaml
+++ b/.github/workflows/sonarqube.yaml
@@ -18,7 +18,7 @@ jobs:
     # manual dispatch from a feature branch causes the same main-overwrite the
     # comment above exists to prevent -- just through a different door.
     if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
+    runs-on: arc-shared
     timeout-minutes: 15
 
     steps:


### PR DESCRIPTION
Moves the SonarQube scan to the in-cluster `arc-shared` runner scale set.

**Why:** SonarQube is moving to a VPN-only internal host that GitHub-hosted runners cannot reach. Every scanning repo must run in-cluster before that switch.

**Why it is safe:** the runner image bakes in `dirmngr`, which `sonarqube-scan-action` v8 needs to verify the scanner's GPG signature. Verified end-to-end on `dodopayments/devops` ([run 32339947799](https://github.com/dodopayments/devops/actions/runs/32339947799)) — signature verified, analysis landed.

**Scope:** one line. `SONAR_HOST_URL` still points at the public host, so this changes *where the job runs*, not what it talks to.

## Why this repo is being rolled separately

Most of the 13 repos have no `run:` steps — checkout plus the scan action. This one does: `npm clean-install` and `npx turbo run test`. The runner image has **no `node` or `npm` as OS tools**, so this depends entirely on `actions/setup-node` provisioning them.

That is expected to work — `setup-node` downloads its own toolchain — but it is a different code path from the trivial repos, so it gets its own PR and its own first-run observation rather than riding along in a batch.

Checked before opening: the 10 `execSync` calls in `rollup.config.js` are all `execSync(\`rimraf ${distDir}\`)`, an npm package resolved from `node_modules/.bin` — not an OS binary. No hidden dependency on something `ubuntu-latest` happens to preinstall.

That trap is real and already bit us: the devops pilot first failed on an unmocked `subprocess.run(["gh", ...])`, because `gh` is preinstalled on hosted runners and absent here. The scan step is rarely the problem; a test shelling out to a binary the hosted image happens to ship is.

## Expect

Longer wall time. Pods are ephemeral with an empty `RUNNER_TOOL_CACHE`, so `setup-node` re-downloads per job. On devops the scan step went 60s → 85s, and a CPU-bound test suite went 151s → 512s (the runner requests 500m CPU against a hosted runner's 4 vCPU). If `npx turbo run test` is CPU-heavy here, expect a comparable slowdown.

If the job **queues** instead of starting, the runner listener is not registered — a cluster-side issue, not this file.