### PR TITLE
ci: npm Trusted Publishing (OIDC), drop NPM_SECRET

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,6 +25,13 @@ jobs:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
+
+      # npm Trusted Publishing (OIDC) needs npm >= 11.5.1; the Node
+      # version above ships an older npm. Pin 11.6.2 for reproducible runs
+      # (11.5.2 fixed an OIDC/provenance ordering bug, 11.6.2 resolves
+      # trusted-publishing failures seen in the wild).
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@11.6.2
       - name: Remove node modules
         run: rm -rf node_modules
       - name: Install dependencies
@@ -56,8 +63,6 @@ jobs:
         if: steps.version_check_core.outputs.should_publish == 'true'
         run: npm publish --provenance --access public
         working-directory: packages/core
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_SECRET }}
 
   release-nextjs:
     name: Release @dodopayments/nextjs
@@ -73,6 +78,13 @@ jobs:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
+
+      # npm Trusted Publishing (OIDC) needs npm >= 11.5.1; the Node
+      # version above ships an older npm. Pin 11.6.2 for reproducible runs
+      # (11.5.2 fixed an OIDC/provenance ordering bug, 11.6.2 resolves
+      # trusted-publishing failures seen in the wild).
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@11.6.2
       - name: Install dependencies
         run: npm install
       - name: Install dependency - Rollup
@@ -105,8 +117,6 @@ jobs:
         if: steps.version_check_nextjs.outputs.should_publish == 'true'
         run: npm publish --provenance --access public
         working-directory: packages/nextjs
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_SECRET }}
 
   release-betterauth:
     name: Release @dodopayments/better-auth
@@ -122,6 +132,13 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
+
+      # npm Trusted Publishing (OIDC) needs npm >= 11.5.1; the Node
+      # version above ships an older npm. Pin 11.6.2 for reproducible runs
+      # (11.5.2 fixed an OIDC/provenance ordering bug, 11.6.2 resolves
+      # trusted-publishing failures seen in the wild).
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@11.6.2
       - name: Install dependencies
         run: npm install
       - name: Build core (ensure up-to-date)
@@ -152,8 +169,6 @@ jobs:
         if: steps.version_check_betterauth.outputs.should_publish == 'true'
         run: npm publish --provenance --access public
         working-directory: packages/betterauth
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_SECRET }}
 
   release-nuxt:
     name: Release @dodopayments/nuxt
@@ -169,6 +184,13 @@ jobs:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
+
+      # npm Trusted Publishing (OIDC) needs npm >= 11.5.1; the Node
+      # version above ships an older npm. Pin 11.6.2 for reproducible runs
+      # (11.5.2 fixed an OIDC/provenance ordering bug, 11.6.2 resolves
+      # trusted-publishing failures seen in the wild).
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@11.6.2
       - name: Install dependencies
         run: npm install
       - name: Install dependency - Rollup
@@ -201,8 +223,6 @@ jobs:
         if: steps.version_check_nuxt.outputs.should_publish == 'true'
         run: npm publish --provenance --access public
         working-directory: packages/nuxt
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_SECRET }}
 
   release-express:
     name: Release @dodopayments/express
@@ -218,6 +238,13 @@ jobs:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
+
+      # npm Trusted Publishing (OIDC) needs npm >= 11.5.1; the Node
+      # version above ships an older npm. Pin 11.6.2 for reproducible runs
+      # (11.5.2 fixed an OIDC/provenance ordering bug, 11.6.2 resolves
+      # trusted-publishing failures seen in the wild).
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@11.6.2
       - name: Install dependencies
         run: npm install
       - name: Install dependency - Rollup
@@ -250,8 +277,6 @@ jobs:
         if: steps.version_check_express.outputs.should_publish == 'true'
         run: npm publish --provenance --access public
         working-directory: packages/express
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_SECRET }}
 
   release-astro:
     name: Release @dodopayments/astro
@@ -267,6 +292,13 @@ jobs:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
+
+      # npm Trusted Publishing (OIDC) needs npm >= 11.5.1; the Node
+      # version above ships an older npm. Pin 11.6.2 for reproducible runs
+      # (11.5.2 fixed an OIDC/provenance ordering bug, 11.6.2 resolves
+      # trusted-publishing failures seen in the wild).
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@11.6.2
       - name: Install dependencies
         run: npm install
       - name: Install dependency - Rollup
@@ -299,8 +331,6 @@ jobs:
         if: steps.version_check_astro.outputs.should_publish == 'true'
         run: npm publish --provenance --access public
         working-directory: packages/astro
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_SECRET }}
 
   release-remix:
     name: Release @dodopayments/remix
@@ -316,6 +346,13 @@ jobs:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
+
+      # npm Trusted Publishing (OIDC) needs npm >= 11.5.1; the Node
+      # version above ships an older npm. Pin 11.6.2 for reproducible runs
+      # (11.5.2 fixed an OIDC/provenance ordering bug, 11.6.2 resolves
+      # trusted-publishing failures seen in the wild).
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@11.6.2
       - name: Install dependencies
         run: npm install
       - name: Install dependency - Rollup
@@ -348,8 +385,6 @@ jobs:
         if: steps.version_check_remix.outputs.should_publish == 'true'
         run: npm publish --provenance --access public
         working-directory: packages/remix
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_SECRET }}
 
   release-sveltekit:
     name: Release @dodopayments/sveltekit
@@ -365,6 +400,13 @@ jobs:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
+
+      # npm Trusted Publishing (OIDC) needs npm >= 11.5.1; the Node
+      # version above ships an older npm. Pin 11.6.2 for reproducible runs
+      # (11.5.2 fixed an OIDC/provenance ordering bug, 11.6.2 resolves
+      # trusted-publishing failures seen in the wild).
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@11.6.2
       - name: Install dependencies
         run: npm install
       - name: Install dependency - Rollup
@@ -397,8 +439,6 @@ jobs:
         if: steps.version_check_sveltekit.outputs.should_publish == 'true'
         run: npm publish --provenance --access public
         working-directory: packages/sveltekit
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_SECRET }}
 
   release-tanstack:
     name: Release @dodopayments/tanstack
@@ -414,6 +454,13 @@ jobs:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
+
+      # npm Trusted Publishing (OIDC) needs npm >= 11.5.1; the Node
+      # version above ships an older npm. Pin 11.6.2 for reproducible runs
+      # (11.5.2 fixed an OIDC/provenance ordering bug, 11.6.2 resolves
+      # trusted-publishing failures seen in the wild).
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@11.6.2
       - name: Install dependencies
         run: npm install
       - name: Install dependency - Rollup
@@ -446,8 +493,6 @@ jobs:
         if: steps.version_check_tanstack.outputs.should_publish == 'true'
         run: npm publish --provenance --access public
         working-directory: packages/tanstack
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_SECRET }}
 
   release-fastify:
     name: Release @dodopayments/fastify
@@ -463,6 +508,13 @@ jobs:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
+
+      # npm Trusted Publishing (OIDC) needs npm >= 11.5.1; the Node
+      # version above ships an older npm. Pin 11.6.2 for reproducible runs
+      # (11.5.2 fixed an OIDC/provenance ordering bug, 11.6.2 resolves
+      # trusted-publishing failures seen in the wild).
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@11.6.2
       - name: Install dependencies
         run: npm install
       - name: Install dependency - Rollup
@@ -495,8 +547,6 @@ jobs:
         if: steps.version_check_fastify.outputs.should_publish == 'true'
         run: npm publish --provenance --access public
         working-directory: packages/fastify
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_SECRET }}
 
   release-hono:
     name: Release @dodopayments/hono
@@ -512,6 +562,13 @@ jobs:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
+
+      # npm Trusted Publishing (OIDC) needs npm >= 11.5.1; the Node
+      # version above ships an older npm. Pin 11.6.2 for reproducible runs
+      # (11.5.2 fixed an OIDC/provenance ordering bug, 11.6.2 resolves
+      # trusted-publishing failures seen in the wild).
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@11.6.2
       - name: Install dependencies
         run: npm install
       - name: Install dependency - Rollup
@@ -544,8 +601,6 @@ jobs:
         if: steps.version_check_hono.outputs.should_publish == 'true'
         run: npm publish --provenance --access public
         working-directory: packages/hono
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_SECRET }}
 
   release-convex:
     name: Release @dodopayments/convex
@@ -561,6 +616,13 @@ jobs:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
+
+      # npm Trusted Publishing (OIDC) needs npm >= 11.5.1; the Node
+      # version above ships an older npm. Pin 11.6.2 for reproducible runs
+      # (11.5.2 fixed an OIDC/provenance ordering bug, 11.6.2 resolves
+      # trusted-publishing failures seen in the wild).
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@11.6.2
       - name: Install dependencies
         run: npm install
       - name: Install dependency - Rollup
@@ -593,8 +655,6 @@ jobs:
         if: steps.version_check_convex.outputs.should_publish == 'true'
         run: npm publish --provenance --access public
         working-directory: packages/convex
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_SECRET }}
 
   release-bun:
     name: Release @dodopayments/bun
@@ -610,6 +670,13 @@ jobs:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
+
+      # npm Trusted Publishing (OIDC) needs npm >= 11.5.1; the Node
+      # version above ships an older npm. Pin 11.6.2 for reproducible runs
+      # (11.5.2 fixed an OIDC/provenance ordering bug, 11.6.2 resolves
+      # trusted-publishing failures seen in the wild).
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@11.6.2
       - name: Install dependencies
         run: npm install
       - name: Install dependency - Rollup
@@ -642,5 +709,3 @@ jobs:
         if: steps.version_check_bun.outputs.should_publish == 'true'
         run: npm publish --provenance --access public
         working-directory: packages/bun
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_SECRET }}


### PR DESCRIPTION
## What

Switch npm publishing from a long-lived `NPM_SECRET` secret to **npm Trusted Publishing over GitHub Actions OIDC** — no token in CI.

## Changes

- **Upgrade npm to `11.6.2`** after `setup-node` (OIDC trusted publishing requires npm >= 11.5.1; the Node version here ships an older npm). Pinned for reproducibility — 11.5.2 fixed an OIDC/provenance ordering bug and 11.6.2 resolves trusted-publishing failures seen in the wild.
- **Drop `env: NODE_AUTH_TOKEN: ${{ secrets.NPM_SECRET }}`** from the publish step(s).
- (no extra permission changes needed — id-token: write and --provenance were already present.)

## Required before the next release (npmjs.com side — cannot be done from code)

Each published package must have a **trusted publisher** registered on npmjs.com pointing at this repo + the workflow file `.github/workflows/release.yaml`, or the first OIDC publish fails auth. This is being handled out-of-band per package (`npm trust github ... --repository dodopayments/dodo-adapters --file release.yaml --allow-publish`). A brand-new package needs a manual first publish before OIDC can take over.

## Why

- Removes a long-lived, exfiltration-prone credential from CI.
- OIDC tokens are short-lived and cryptographically scoped to this workflow file + commit SHA.
- Mirrors the proven conversion in `dodopayments/dualmark` (#91).
